### PR TITLE
Add -mwindows to link flags, correct wording

### DIFF
--- a/FindSDL2.cmake
+++ b/FindSDL2.cmake
@@ -118,11 +118,10 @@ IF(NOT APPLE)
 	FIND_PACKAGE(Threads)
 ENDIF(NOT APPLE)
 
-# MinGW needs an additional library, mwindows
-# It's total link flags should look like -lmingw32 -lSDL2main -lSDL2 -lmwindows
-# (Actually on second look, I think it only needs one of the m* libraries.)
+# MinGW needs an additional link flag, -mwindows
+# It's total link flags should look like -lmingw32 -lSDL2main -lSDL2 -mwindows
 IF(MINGW)
-	SET(MINGW32_LIBRARY mingw32 CACHE STRING "mwindows for MinGW")
+	SET(MINGW32_LIBRARY mingw32 "-mwindows" CACHE STRING "mwindows for MinGW")
 ENDIF(MINGW)
 
 IF(SDL2_LIBRARY_TEMP)
@@ -166,4 +165,3 @@ message("</FindSDL2.cmake>")
 INCLUDE(FindPackageHandleStandardArgs)
 
 FIND_PACKAGE_HANDLE_STANDARD_ARGS(SDL2 REQUIRED_VARS SDL2_LIBRARY SDL2_INCLUDE_DIR)
-


### PR DESCRIPTION
mwindows is not a library. Quoting from
https://cygwin.com/ml/cygwin/2007-04/msg00027.html:

> > What does -mwindows mean?
> 
> It just means to set a flag in the PE header that tells the OS not to
> allocate a console for the program when started.  This is usually the
> desired behavior when the program has a GUI, because you don't want the
> console window appearing in that case.  It is really unfortunate that
> somebody decided to call this "-mwindows", it should really be
> -mno-console, which compliments its reciprocal option -mconsole (which
> is the default.)
